### PR TITLE
remove deprecations

### DIFF
--- a/pearback/_pearback.py
+++ b/pearback/_pearback.py
@@ -184,8 +184,9 @@ def print_manifest(backup, header=True, sep=None):
         elif isinstance(val, dict):
             field = "#"+field
             val = len(val)
-        elif isinstance(val, _plistlib.Data):
-            continue
+# .Data is deprecated
+        elif isinstance(val, bytes):
+           continue
         elif isinstance(val, _datetime):
             val = val.isoformat()
         toprint[field] = val
@@ -463,7 +464,10 @@ def _read_status_plist(statusfile):
     Here, the toplevel fields of the plist are converted into namedtuple
     fields. Subfields are left as dictionaries. '''
 
-    s = _plistlib.readPlist(statusfile)
+# deprecated
+#    s = _plistlib.readPlist(statusfile)
+    with open(statusfile, 'rb') as f:
+        s = _plistlib.load(f)
 
     # only convert toplevel fields into namedtuple fields, since we have
     # encountered names that are not proper Python identifiers in some of the
@@ -481,7 +485,11 @@ def _read_manifest_plist(manifestplist):
     Here, the toplevel fields of the plist are converted into namedtuple
     fields. Subfields are left as dictionaries. '''
 
-    m = _plistlib.readPlist(manifestplist)
+# deprecated
+#    m = _plistlib.readPlist(manifestplist)
+    with open(manifestplist, 'rb') as f:
+        m = _plistlib.load(f)
+
     # here too, only convert toplevel fields into namedtuple fields
     keys = sorted(m.keys())
     vals = [m[k] for k in keys]


### PR DESCRIPTION
Correct code which is deprecated since Python 3.4 (deprecations were removed in Python 3.9). I removed the use of biplist, which is not necessary anymore, plistlib has no all what one will need. Program works with backups from IOS13.